### PR TITLE
Feature: add git-config-setup.sh to bash_profile

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -9,6 +9,10 @@ if [ -f ~/.git-prompt.sh ]; then
   . ~/.git-prompt.sh
 fi
 
+if [ -f ~/.git-config-setup.sh ]; then
+  . ~/.git-config-setup.sh
+fi
+
 if [ -f ~/.alias.sh ]; then
   . ~/.alias.sh
 fi

--- a/.git-alias.sh
+++ b/.git-alias.sh
@@ -2,50 +2,50 @@
 #
 # Aliases to use within git
 
-git config --global alias.co checkout
-git config --global alias.ci '!git commit --verbose'
-git config --global alias.st status
-git config --global alias.br branch
-git config --global alias.cp 'cherry-pick'
-git config --global alias.hist "log --format=format:'%C(bold yellow)%h%C(reset) %C(blue)(%ar)%C(reset) - %C(white)%s%C(reset) %C(dim white)[%an]%C(reset)%C(dim yellow)%d%C(reset)' --graph --decorate"
-git config --global alias.type 'cat-file -t'
-git config --global alias.dump 'cat-file -p'
-git config --global alias.last 'log -1 HEAD'
+git config --global --replace-all alias.co checkout
+git config --global --replace-all alias.ci '!git commit --verbose'
+git config --global --replace-all alias.st status
+git config --global --replace-all alias.br branch
+git config --global --replace-all alias.cp 'cherry-pick'
+git config --global --replace-all alias.hist "log --format=format:'%C(bold yellow)%h%C(reset) %C(blue)(%ar)%C(reset) - %C(white)%s%C(reset) %C(dim white)[%an]%C(reset)%C(dim yellow)%d%C(reset)' --graph --decorate"
+git config --global --replace-all alias.type 'cat-file -t'
+git config --global --replace-all alias.dump 'cat-file -p'
+git config --global --replace-all alias.last 'log -1 HEAD'
 
 # ff merge or pull --rebase is better than standard merge when updating master or develop branches
 # No accidental or unnecessary merge commits. Avoid stupid git mistakes
-git config --global alias.fp '!git fetch -p origin'
-git config --global alias.ffm 'merge --ff-only'
-git config --global alias.cob 'checkout -b'
-git config --global alias.la '!git config -l | grep alias | cut -c 7-'
-git config --global alias.ac '!git add . && git commit --verbose'
-git config --global alias.pfwl 'push --force-with-lease origin'
-git config --global alias.syncdev '!git co develop && git fp && git ffm origin/develop'
-git config --global alias.syncmaster '!git co master && git fp && git ffm origin/master'
-git config --global alias.syncall '!git syncmaster && git syncdev'
+git config --global --replace-all alias.fp '!git fetch -p origin'
+git config --global --replace-all alias.ffm 'merge --ff-only'
+git config --global --replace-all alias.cob 'checkout -b'
+git config --global --replace-all alias.la '!git config -l | grep alias | cut -c 7-'
+git config --global --replace-all alias.ac '!git add . && git commit --verbose'
+git config --global --replace-all alias.pfwl 'push --force-with-lease origin'
+git config --global --replace-all alias.syncdev '!git co develop && git fp && git ffm origin/develop'
+git config --global --replace-all alias.syncmaster '!git co master && git fp && git ffm origin/master'
+git config --global --replace-all alias.syncall '!git syncmaster && git syncdev'
 
 # This commits everything in your working directory and then does a hard reset to remove that commit.
 # The nice thing is, the commit is still there, but it’s just unreachable. Unreachable commits are a bit
 # inconvenient to restore, but at least they are still there. You can run the git reflog command and find
 # the SHA of the commit if you realize later that you made a mistake with the reset. The commit message will
 # be “WIPE SAVEPOINT” in this case.
-git config --global alias.wipe '!git add -A && git commit -qm "WIPE SAVEPOINT" && git reset HEAD~1 --hard'
+git config --global --replace-all alias.wipe '!git add -A && git commit -qm "WIPE SAVEPOINT" && git reset HEAD~1 --hard'
 
 # Adds all changes including untracked files and creates a commit
-git config --global alias.save '!git add -A && git commit -m "SAVEPOINT"'
+git config --global --replace-all alias.save '!git add -A && git commit -m "SAVEPOINT"'
 
 # Only commits tracked changes
-git config --global alias.wip 'commit -am "WIP"'
+git config --global --replace-all alias.wip 'commit -am "WIP"'
 
 # Resets the previous commit, but keeps all the changes from that commit in the working directory.
 # Slap people in the face that use `git reset HEAD --hard`. It’s a bad idea. Don’t do it!
-git config --global alias.undo 'reset HEAD~1 --mixed'
+git config --global --replace-all alias.undo 'reset HEAD~1 --mixed'
 
 # Amends current changes to previous commit
-git config --global alias.amend 'commit -a --amend'
+git config --global --replace-all alias.amend 'commit -a --amend'
 
 # Terminal diff of all changes
-git config --global alias.filelog 'log -u'
+git config --global --replace-all alias.filelog 'log -u'
 
 # Same as `hist` without the bells and whistles
-git config --global alias.logtree 'log --graph --oneline --decorate --all'
+git config --global --replace-all alias.logtree 'log --graph --oneline --decorate --all'

--- a/.git-config-setup.sh
+++ b/.git-config-setup.sh
@@ -17,7 +17,7 @@ git config --global branch.autosetupmerge true
 
 # When pushing without giving a refspec, push the current branch to its upstream branch. 
 # See the git config man page for more possible options.
-git config --global push.default tracking
+git config --global push.default current
 
 # Enable the recording of resolved conflicts, so that identical hunks can be resolved automatically later on.
 git config --global rerere.enabled true

--- a/.git-config-setup.sh
+++ b/.git-config-setup.sh
@@ -4,26 +4,26 @@
 # File to be run once to set up some nice standard git global setting
 
 # Allow all Git commands to use colored output, if possible
-git config --global color.ui auto
+git config --global --replace-all color.ui auto
 
 # Tell Git which whitespace problems it should recognize
-git config --global core.whitespace trailing-space,space-before-tab
+git config --global --replace-all core.whitespace trailing-space,space-before-tab
 
 # Tell git diff to use mnemonic prefixes (index, work tree, commit, object) instead of the standard a and b notation
-git config --global diff.mnemonicprefix true
+git config --global --replace-all diff.mnemonicprefix true
 
 # When branching off a remote branch, automatically let the local branch track the remote branch
-git config --global branch.autosetupmerge true
+git config --global --replace-all branch.autosetupmerge true
 
 # When pushing without giving a refspec, push the current branch to its upstream branch. 
 # See the git config man page for more possible options.
-git config --global push.default current
+git config --global --replace-all push.default current
 
 # Enable the recording of resolved conflicts, so that identical hunks can be resolved automatically later on.
-git config --global rerere.enabled true
+git config --global --replace-all rerere.enabled true
 
 # Auto update/stage rerere on merge fixes (works on rebase too)
-git config --global rerere.autoupdate true
+git config --global --replace-all rerere.autoupdate true
 
 # Set git to globally use templates directory
-git config --global init.templatedir '~/.git-templates'
+git config --global --replace-all init.templatedir '~/.git-templates'


### PR DESCRIPTION
I created the file for setting up git config but I somehow overlooked executing the script on install and when reloading the profile.

- Adds execution of `.git-config-setup.sh` to `.bash_profile`
- Fixed issue with tracking branch so you don't need to set a tracking branch every time on the first push
- Cleans up `git config` -l list by using the `--replace-all` flag when setting config options